### PR TITLE
Update repository.tf

### DIFF
--- a/repository.tf
+++ b/repository.tf
@@ -65,7 +65,7 @@ resource "github_branch_protection" "all" {
 resource "github_repository_tag_protection" "version" {
   for_each = var.repositories
 
-  repository = github_repository.this[each.key].name
+  repository = github_repository.this[each.key].full_name
   pattern    = "v*"
 }
 


### PR DESCRIPTION
According to https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository the github_repository does not expose an attribute called `name` it does how ever expose one that is called `full_name`