### PR TITLE
Remove tag protection

### DIFF
--- a/repository.tf
+++ b/repository.tf
@@ -62,13 +62,6 @@ resource "github_branch_protection" "all" {
   require_signed_commits = true
 }
 
-resource "github_repository_tag_protection" "version" {
-  for_each = var.repositories
-
-  repository = github_repository.this[each.key].name
-  pattern    = "v*"
-}
-
 resource "github_team_repository" "this" {
   for_each = { for entry in flatten([for repo_key, repo in var.repositories : [
     for team, permission in repo.team_permission : {


### PR DESCRIPTION
Adding a tag protection allows only maintainers and admins to be able to create these tags, and only admins will be able to modify or delete these tags