### PR TITLE
fix/last push approval required when 0 review required

### DIFF
--- a/repository.tf
+++ b/repository.tf
@@ -42,7 +42,7 @@ resource "github_branch_protection" "main" {
     required_approving_review_count = each.value.required_approvals
     require_code_owner_reviews      = each.value.require_code_owner_reviews
     dismiss_stale_reviews           = true
-    require_last_push_approval      = true
+    require_last_push_approval      = each.value.required_approvals > 0
   }
 
   required_status_checks {


### PR DESCRIPTION
`require_last_push_approval = true` prevents merging even when `required_approving_review_count = 0`

![image](https://github.com/pippiio/github-organization/assets/19843915/b6b5675d-37c8-49ee-91a0-de780c493081)

![image](https://github.com/pippiio/github-organization/assets/19843915/72216ea9-7106-461e-b840-e9ef581ae576)
