### PR TITLE
Allowing regular users to push to default branches

### DIFF
--- a/repository.tf
+++ b/repository.tf
@@ -46,10 +46,10 @@ resource "github_repository_ruleset" "default" {
   }
 
   rules {
-    creation            = true # restrict creation on default branch
-    update              = true
-    deletion            = true
-    required_signatures = true
+    creation            = true  # restrict creation of default branch
+    update              = false # allows PR merges on default branch
+    deletion            = true  # restrict deletion of default branch
+    required_signatures = true  # require signatures on default branch
 
     pull_request {
       required_approving_review_count   = each.value.required_approvals


### PR DESCRIPTION
According to this documentation or PR merges is blocked do to this setting https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#restrict-updates 